### PR TITLE
[ci] add ruff style check

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -1,0 +1,26 @@
+name: Style Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff formatting check
+        run: ruff format --check .
+
+      - name: Run ruff style check
+        run: ruff check .


### PR DESCRIPTION
## Summary
- add workflow that checks styling via `ruff`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 's3fs')*

------
https://chatgpt.com/codex/tasks/task_e_683e650397a48328998426c0720582d0