### PR TITLE
[docs] add overviews to module READMEs

### DIFF
--- a/module-1/PRACTICE.md
+++ b/module-1/PRACTICE.md
@@ -1,5 +1,16 @@
 # Practice
 
+This module focuses on drafting your ML system design and containerizing a
+simple application. You'll also create CI/CD pipelines and basic Kubernetes
+manifests.
+
+### Key tasks
+
+- Draft a design document using the MLOps template.
+- Build and push a Docker image.
+- Set up GitHub Actions for CI/CD.
+- Deploy your image to a local Kubernetes cluster.
+
 ***
 
 # H1: Initial Design Draft

--- a/module-1/README.md
+++ b/module-1/README.md
@@ -1,16 +1,23 @@
+
 # Module 1
 
-![alt text](./../docs/into.jpg)
+![Container introduction](./../docs/into.jpg)
 
-# Practice 
+## Overview
+
+This module introduces containerization and basic Kubernetes usage.
+You'll learn how to build Docker images, push them to a registry and
+deploy simple workloads on a local Kubernetes cluster.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-***
+---
 
-# Reference implementation
+## Reference implementation
 
-***
+---
 
 # H1: Initial Design Draft
 

--- a/module-2/PRACTICE.md
+++ b/module-2/PRACTICE.md
@@ -1,5 +1,15 @@
 # Practice
 
+In this module you'll experiment with storage options, implement a MinIO
+client, and benchmark data ingestion and inference performance.
+
+### Key tasks
+
+- Deploy MinIO locally with Docker and Kubernetes.
+- Build a CRUD Python client with tests.
+- Benchmark Pandas storage formats.
+- Measure inference speed using multiple workers.
+
 ***
 
 # H3: Data storage & processing

--- a/module-2/README.md
+++ b/module-2/README.md
@@ -1,16 +1,21 @@
 # Module 2
 
-![alt text](./../docs/data.jpg)
+![Data management](./../docs/data.jpg)
 
-# Practice
+## Overview
+
+This module covers data storage and processing. You'll deploy MinIO locally,
+benchmark data formats and explore streaming datasets and vector databases.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-***
+---
 
-# Reference implementation
+## Reference implementation
 
-***
+---
 
 # Minio
 

--- a/module-3/PRACTICE.md
+++ b/module-3/PRACTICE.md
@@ -1,5 +1,15 @@
 # Practice
 
+This module guides you through setting up experiment tracking,
+hyperparameter search and model documentation.
+
+### Key tasks
+
+- Train a model using W&B logging.
+- Run hyperparameter search.
+- Generate a model card.
+- Add tests for your data and model.
+
 ***
 
 # H5: Training & Experiments

--- a/module-3/README.md
+++ b/module-3/README.md
@@ -1,16 +1,21 @@
 # Module 3
 
-![alt text](./../docs/experiments.jpg)
+![Experiment tracking](./../docs/experiments.jpg)
 
-# Practice
+## Overview
+
+Here we focus on training workflows, experiment tracking and configuration
+management.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-***
+---
 
-# Reference implementation
+## Reference implementation
 
-***
+---
 
 ## Project stucture
 

--- a/module-4/PRACTICE.md
+++ b/module-4/PRACTICE.md
@@ -1,6 +1,15 @@
-# Practice 
+# Practice
 
-*** 
+Build end-to-end training and inference pipelines using Kubeflow,
+Airflow and Dagster.
+
+### Key tasks
+
+- Deploy Kubeflow pipelines and write training/inference DAGs.
+- Deploy Airflow with KubernetesPodOperator.
+- Implement the same logic in Dagster.
+
+***
 
 
 # H7: Kubeflow + AirFlow pipelines

--- a/module-4/README.md
+++ b/module-4/README.md
@@ -1,16 +1,21 @@
 # Module 4
 
-![alt text](./../docs/pipelines.jpg)
+![Pipelines](./../docs/pipelines.jpg)
 
-# Practice 
+## Overview
+
+This module demonstrates pipeline orchestration using Airflow,
+Kubeflow and Dagster.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-***
+---
 
-# Reference implementation
+## Reference implementation
 
-***
+---
 
 # Setup
 

--- a/module-5/PRACTICE.md
+++ b/module-5/PRACTICE.md
@@ -1,5 +1,15 @@
 # Practice
 
+Create web UIs and APIs for your model and compare different inference servers.
+
+### Key tasks
+
+- Build Streamlit and Gradio interfaces with tests.
+- Implement a FastAPI server.
+- Deploy the API and UI to Kubernetes.
+- Experiment with Seldon, KServe and Triton.
+
+
 ***
 
 # H9: API serving

--- a/module-5/README.md
+++ b/module-5/README.md
@@ -1,16 +1,21 @@
 # Module 5
 
-![alt text](./../docs/serving.jpg)
+![Model serving](./../docs/serving.jpg)
 
-# Practice
+## Overview
+
+This module walks through deploying APIs and UIs for your models and
+integrating inference servers like Triton and vLLM.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-***
+---
 
-# Reference implementation
+## Reference implementation
 
-***
+---
 
 
 # Setup

--- a/module-6/PRACTICE.md
+++ b/module-6/PRACTICE.md
@@ -1,6 +1,15 @@
-# Practice 
+# Practice
 
-*** 
+Benchmark and scale your model server, then explore optimization
+techniques such as quantization.
+
+### Key tasks
+
+- Implement dynamic batching and ensembles.
+- Benchmark REST and gRPC performance.
+- Apply quantization or pruning.
+
+***
 
 # H11: Advanced features & benchmarking
 

--- a/module-6/README.md
+++ b/module-6/README.md
@@ -1,16 +1,21 @@
 # Module 6
 
-![alt text](./../docs/serving.jpg)
+![Scaling and optimization](./../docs/serving.jpg)
 
-# Practice 
+## Overview
+
+This module covers benchmarking, autoscaling and model optimization
+techniques such as quantization.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-*** 
+---
 
-# Reference implementation
+## Reference implementation
 
-*** 
+---
 
 
 

--- a/module-7/PRACTICE.md
+++ b/module-7/PRACTICE.md
@@ -1,6 +1,14 @@
-# Practice 
+# Practice
 
-*** 
+Integrate monitoring tools and add drift detection to your pipelines.
+
+### Key tasks
+
+- Instrument your app with SigNoz.
+- Create a Grafana dashboard.
+- Add simple drift detection logic.
+
+***
 
 
 # H13: Monitoring and observability

--- a/module-7/README.md
+++ b/module-7/README.md
@@ -1,16 +1,21 @@
 # Module 7
 
-![alt text](./../docs/monitoring.jpg)
+![Monitoring](./../docs/monitoring.jpg)
 
-# Practice 
+## Overview
+
+This module sets up observability for ML applications using SigNoz,
+Grafana and Seldon analytics.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-*** 
+---
 
-# Reference implementation
+## Reference implementation
 
-*** 
+---
 
 
 

--- a/module-8/PRACTICE.md
+++ b/module-8/PRACTICE.md
@@ -1,6 +1,15 @@
-# Practice 
+# Practice
 
-*** 
+Compare managed ML platforms and implement a multi-model setup on
+SageMaker and Vertex AI.
+
+### Key tasks
+
+- Deploy multiple models on AWS SageMaker.
+- Deploy multiple models on GCP Vertex AI.
+- Summarize pros and cons of each platform.
+
+***
 
 # H15: ML platforms
 

--- a/module-8/README.md
+++ b/module-8/README.md
@@ -1,16 +1,21 @@
 # Module 8
 
-![alt text](./../docs/monitoring.jpg)
+![Cloud platforms](./../docs/monitoring.jpg)
 
-# Practice 
+## Overview
+
+Explore buy vs build decisions and deploy multi-model endpoints on AWS
+SageMaker and GCP Vertex AI.
+
+## Practice
 
 [Practice task](./PRACTICE.md)
 
-*** 
+---
 
-# Reference implementation
+## Reference implementation
 
-*** 
+---
 
 ## Buy vs Build 
 


### PR DESCRIPTION
## Summary
- clarify module READMEs with overview sections
- add task summaries to PRACTICE files

## Testing
- `ruff format --diff`
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683e6beb73b88328bb35914c43ad7b7a