### PR TITLE
[module-2] remove dvc homework

### DIFF
--- a/module-2/PRACTICE.md
+++ b/module-2/PRACTICE.md
@@ -66,7 +66,6 @@ client, and benchmark data ingestion and inference performance.
 ## Task:
 
 - Google doc containing dataset labeling section: Estimate costs and time based on your experience labeling ~50 samples, provide instructions for future data labeling, and add a flow for data enrichment in production.
-- PR1: Commit your data with DVC into the GitHub repo.
 - PR2: Write code to deploy a labeling tool (e.g., Label Studio, Argilla), including README instructions.
 - PR3 (optional): Write code to generate a synthetic dataset with ChatGPT.
 - PR4 (optional): Write code to test your data after labeling (can use Cleanlab or Deepchecks).

--- a/module-2/README.md
+++ b/module-2/README.md
@@ -161,65 +161,6 @@ python vector-db/rag_cli_application.py query-existing-vector-db  --query 'compl
 Storage [diagram](https://lancedb.github.io/lancedb/concepts/storage/)
 
 
-# DVC
-
-Init DVC
-
-```bash
-dvc init --subdir
-git status
-git commit -m "Initialize DVC"
-```
-
-Add data
-
-```bash
-mkdir data
-touch ./data/big-data.csv
-```
-
-Add to dvc
-
-```bash
-dvc add ./data/big-data.csv
-git add data/.gitignore data/big-data.csv.dvc
-git commit -m "Add raw data"
-```
-
-Add remote
-
-You can use Minio via AWS CLI
-
-```bash
-export AWS_ACCESS_KEY_ID=minioadmin
-export AWS_SECRET_ACCESS_KEY=minioadmin
-export AWS_ENDPOINT_URL=http://127.0.0.1:9000
-```
-
-
-```bash
-aws s3api create-bucket --bucket ml-data
-
-dvc remote add -d minio s3://ml-data
-dvc remote modify minio endpointurl $AWS_ENDPOINT_URL
-```
-
-Save code to git
-
-```bash
-git add .dvc/config
-git commit -m "Configure remote storage"
-git push 
-```
-
-Save data to storage
-
-```bash
-dvc push
-```
-
-- <https://dvc.org/doc/start/data-management>
-- <https://github.com/iterative/dataset-registry>
 
 ## Labeling with Argilla
 


### PR DESCRIPTION
## Summary
- drop the DVC instructions from the README
- remove the DVC task in PRACTICE

## Testing
- `ruff format`
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 's3fs', 'great_expectations', 'httpx', 'locust')*

------
https://chatgpt.com/codex/tasks/task_e_6840de6941bc83288da067599722196b