### PR TITLE
[module-1] fix modal path

### DIFF
--- a/.github/workflows/module-1-advanced.yaml
+++ b/.github/workflows/module-1-advanced.yaml
@@ -57,4 +57,4 @@ jobs:
 
       - name: Run function
         run: |
-          modal run ./module-1/modal_hello_world.py
+          modal run ./module-1/modal-examples/modal_hello_world.py


### PR DESCRIPTION
## Summary
- reference correct path to example Modal file in CI

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 's3fs')*

------
https://chatgpt.com/codex/tasks/task_e_68438dc1c95483289154e99e792e6700